### PR TITLE
Changing provider name from linkedin to LINKEDIN

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -1,7 +1,7 @@
 # Original project : sabyasachibiswal https://github.com/sabyasachibiswal/angular5-social-login
 
 
-Social login api for Angular 6. Includes Facebook, Google login and Linkedin. 
+Social login api for Angular 6. Includes Facebook, Google and Linkedin. 
 
 ![Generic badge](https://img.shields.io/badge/build-passing-green.svg)
 ![Generic badge](https://img.shields.io/badge/Angular-6-green.svg)
@@ -14,7 +14,7 @@ Social login api for Angular 6. Includes Facebook, Google login and Linkedin.
 ### Install via npm 
 
 ```sh
-npm install --save angular-6-social-login
+npm install --save angular-6-social-login-fixed
 ```
 
 ### Import the module
@@ -30,7 +30,7 @@ import {
     GoogleLoginProvider,
     FacebookLoginProvider,
     LinkedinLoginProvider,
-} from "angular-6-social-login";
+} from "angular-6-social-login-fixed";
 
 
 // Configs 
@@ -83,7 +83,7 @@ import {
     AuthService,
     FacebookLoginProvider,
     GoogleLoginProvider
-} from 'angular-6-social-login';
+} from 'angular-6-social-login-fixed';
 
 @Component({
   selector: 'app-signin',
@@ -98,13 +98,17 @@ export class SigninComponent implements OnInit {
   
   public socialSignIn(socialPlatform : string) {
     let socialPlatformProvider;
-    if(socialPlatform == "facebook"){
-      socialPlatformProvider = FacebookLoginProvider.PROVIDER_ID;
-    }else if(socialPlatform == "google"){
-      socialPlatformProvider = GoogleLoginProvider.PROVIDER_ID;
-    } else if (socialPlatform == "linkedin") {
-      socialPlatformProvider = LinkedinLoginProvider.PROVIDER_ID;
-    }
+        switch (socialPlatform) {
+        case 'facebook':
+            socialPlatformProvider = FacebookLoginProvider.PROVIDER_ID;
+            break;
+        case 'google':
+            socialPlatformProvider = GoogleLoginProvider.PROVIDER_ID;
+            break;
+        case 'linkedin':
+            socialPlatformProvider = LinkedinLoginProvider.PROVIDER_ID;
+            break;
+        }
     
     this.socialAuthService.signIn(socialPlatformProvider).then(
       (userData) => {
@@ -129,7 +133,8 @@ In `signin.component.html`,
 </h1>
 
 <button (click)="socialSignIn('facebook')">Sign in with Facebook</button>
-<button (click)="socialSignIn('google')">Sign in with Google</button>              
+<button (click)="socialSignIn('google')">Sign in with Google</button>
+<button (click)="socialSignIn('linkedin')">Sign in with Google</button>         
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "angular-6-social-login",
-  "version": "1.1.0",
-  "description": "Agular 6 : Social Login (Facebook and Google)",
+  "name": "angular-6-social-login-fixed",
+  "version": "1.0.0",
+  "description": "Agular 6: Social Login (Facebook, Google and Linkedin)",
   "scripts": {
     "build": "gulp build",
     "build:watch": "gulp",
@@ -13,11 +13,11 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/high54/angular-6-social-login"
+    "url": "https://github.com/AlexandreVeronezi/angular-6-social-login"
   },
   "author": {
-    "name": "Julien Bertacco",
-    "email": "julien.bertacco@gmail.com"
+    "name": "Alexandre Veronezi",
+    "email": "alexandre.sveronezi@gmail.com"
   },
   "keywords": [
     "angular",

--- a/src/providers/linkedin-login-provider.ts
+++ b/src/providers/linkedin-login-provider.ts
@@ -11,7 +11,7 @@ export class LinkedinLoginProvider extends BaseLoginProvider {
   constructor(private clientId: string) {
     super();
     this.loginProviderObj.id = clientId;
-    this.loginProviderObj.name = 'linkedin';
+    this.loginProviderObj.name = 'LINKEDIN';
     this.loginProviderObj.url = 'https://platform.linkedin.com/in.js';
   }
 


### PR DESCRIPTION
I was getting error "api key invalid" when i try to login with linkedin.
I fixed changing provider name from linkedin to Linkedin on file "..\src\providers\linkedin-login-provider.ts" line 14.