### PR TITLE
Added Revoke access function  for revoking token 

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -118,9 +118,41 @@ export class SigninComponent implements OnInit {
   
 }
 ```
+In `the profile component,the page After login you give your user the access profile.component.ts`,
+```javascript
+public unlinkaccount(socialPlatform : string) {
+    let socialPlatformProvider;
+    if(socialPlatform === "facebook"){
+      socialPlatformProvider = FacebookLoginProvider.PROVIDER_ID;
+      socialPlatformProvider = GoogleLoginProvider.PROVIDER_ID;
+      this.socialAuthService.revokeAccess(this.userid).then(
+        (revokeres) => {
+                console.log(revokeres);
+                //the url to redirect after revocation
+                this.router.navigate(['/login',{unlinkmessage:'You have successfully unlinked your account'}]);
+        }
+        );
+    }else if(socialPlatform === "google"){
+      socialPlatformProvider = GoogleLoginProvider.PROVIDER_ID;
+      this.socialAuthService.revokeAccess(this.userid).then(
+        (revokeres) => {
+                console.log(revokeres);
+                //the url to redirect after revocation
+                this.router.navigate(['/login',{unlinkmessage:revokeres}]);
+        }
+        );
+    }
+  }
+```
+In `profile.component.html`
+```html
+<h1>
+Unlink {{provider}} Account
+</h1>
 
-
-
+ <button (click)="unlinkaccount(provider)" *ngIf="provider" color="warn">Unlink {{provider}} account</button>
+ 
+```
 In `signin.component.html`,
 
 ```html

--- a/src/auth.service.ts
+++ b/src/auth.service.ts
@@ -82,5 +82,23 @@ export class AuthService {
       }
     });
   }
-
+  revokeAccess(userid:string): Promise<any> {
+    var _this = this;
+        return new Promise(function (resolve, reject) {
+            if (_this._user && _this._user.provider) {
+                let /** @type {?} */ providerId = _this._user.provider;
+                let /** @type {?} */ providerObject = _this.providers.get(providerId);
+                providerObject.revokeAccess(userid).then(function (revokeres) {
+                    _this._user = null;
+                    _this._authState.next(null);
+                    resolve(revokeres);
+                }).catch(function (err) {
+                    _this._authState.next(null);
+                });
+            }
+            else {
+                reject(AuthService.LOGIN_PROVIDER_NOT_FOUND);
+            }
+        });
+  }
 }

--- a/src/entities/base-login-provider.ts
+++ b/src/entities/base-login-provider.ts
@@ -7,7 +7,7 @@ export abstract class BaseLoginProvider implements LoginProvider {
   abstract initialize(): Promise<SocialUser>;
   abstract signIn(): Promise<SocialUser>;
   abstract signOut(): Promise<any>;
-
+  abstract revokeAccess(userid:string):Promise<any>;
   loadScript(obj: LoginProviderClass, onload: any): void {
     if (document.getElementById(obj.name)) { return; }
     let signInJS = document.createElement('script');

--- a/src/entities/login-provider.ts
+++ b/src/entities/login-provider.ts
@@ -4,5 +4,6 @@ export interface LoginProvider {
   initialize(): Promise<SocialUser>;
   signIn(): Promise<SocialUser>;
   signOut(): Promise<any>;
+  revokeAccess(userid:string):Promise<any>;
 }
 

--- a/src/providers/facebook-login-provider.ts
+++ b/src/providers/facebook-login-provider.ts
@@ -69,5 +69,11 @@ export class FacebookLoginProvider extends BaseLoginProvider {
       });
     });
   }
-
+  revokeAccess(userid:string): Promise<any>{
+    return new Promise(function (resolve, reject) {
+      FB.api(`/${userid}/permissions`,'DELETE',{},function (response) {
+          resolve('Account Unlink success');
+      });
+  });
+  }
 }

--- a/src/providers/google-login-provider.ts
+++ b/src/providers/google-login-provider.ts
@@ -68,5 +68,18 @@ export class GoogleLoginProvider extends BaseLoginProvider {
       });
     });
   }
+  revokeAccess(userid:string): Promise<any>{
+    var _this = this;
+    return new Promise(function (resolve, reject) {
+      _this.auth2.disconnect().then(function (err) {
+          if (err) {
+              reject(err);
+          }
+          else {
+              resolve('Google account Unlink success');
+          }
+      });
+  });
+  }
 
 }


### PR DESCRIPTION
After user has logged in, for giving user the ability to unlink their providers account.
The function calls the provider SDK API to revoke access token given to the app for access of user profile.
Google API disconnect()  function returns empty object and facebook returns {'success':'ok'} object.
 Any comments are  appreciated. @high54 @sabyasachibiswal